### PR TITLE
Bug fix: unhandled instance error when called on non-root instance

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -4,10 +4,11 @@ if ( defined( 'MWSTAKE_MEDIAWIKI_COMPONENT_PROCESSMANAGER_VERSION' ) ) {
 	return;
 }
 
-define( 'MWSTAKE_MEDIAWIKI_COMPONENT_PROCESSMANAGER_VERSION', '1.1.0' );
+define( 'MWSTAKE_MEDIAWIKI_COMPONENT_PROCESSMANAGER_VERSION', '1.2.0' );
 
 \MWStake\MediaWiki\ComponentLoader\Bootstrapper::getInstance()
 	->register( 'processmanager', function () {
+		$GLOBALS['mwscProcessManagerAdditonalExecutionCLIScriptArgs'][] = [];
 		$GLOBALS['wgServiceWiringFiles'][] = __DIR__ . '/includes/ServiceWiring.php';
 		$GLOBALS['wgHooks']['LoadExtensionSchemaUpdates'][] = function ( DatabaseUpdater $updater ) {
 			$updater->addExtensionTable( 'processes', __DIR__ . '/db/processes.sql' );

--- a/composer.json
+++ b/composer.json
@@ -43,5 +43,10 @@
 			"minus-x fix .",
 			"phpcbf"
 		]
+	},
+	"config": {
+		"allow-plugins": {
+			"composer/installers": true
+		}
 	}
 }

--- a/includes/ServiceWiring.php
+++ b/includes/ServiceWiring.php
@@ -4,6 +4,7 @@ use MWStake\MediaWiki\Component\ProcessManager\ProcessManager;
 
 return [
 	'ProcessManager' => static function ( \MediaWiki\MediaWikiServices $services ) {
-		return new ProcessManager( $services->getDBLoadBalancer() );
+		return new ProcessManager( $services->getDBLoadBalancer(),
+		$GLOBALS['mwscProcessManagerAdditonalExecutionCLIScriptArgs'] );
 	}
 ];

--- a/src/ManagedProcess.php
+++ b/src/ManagedProcess.php
@@ -26,9 +26,10 @@ class ManagedProcess {
 	 * @param ProcessManager $manager
 	 * @param array|null $data
 	 * @param string|null $pid ID of the exsting process to continue
+	 * @param array $addInfo=[] Additional information can be passed inside the array or [] if none
 	 * @return string ProcessID
 	 */
-	public function start( ProcessManager $manager, $data = [], $pid = null ) {
+	public function start( ProcessManager $manager, $data = [], $pid = null, $addInfo = [] ) {
 		$scriptPath = dirname( __DIR__ ) . '/maintenance/processExecution.php';
 		$maintenancePath = $GLOBALS['IP'] . '/maintenance/Maintenance.php';
 
@@ -50,7 +51,7 @@ class ManagedProcess {
 		}
 
 		$this->parentProcess = new AsyncProcess( [
-			$phpBinaryPath, $scriptPath, $maintenancePath, $pid
+			$phpBinaryPath, $scriptPath, $maintenancePath, $pid, $addInfo
 		] );
 		$input = new InputStream();
 		$input->write( json_encode( [ 'steps' => $this->steps, 'data' => $data ] ) );

--- a/src/ManagedProcess.php
+++ b/src/ManagedProcess.php
@@ -26,7 +26,7 @@ class ManagedProcess {
 	 * @param ProcessManager $manager
 	 * @param array|null $data
 	 * @param string|null $pid ID of the exsting process to continue
-	 * @param array $addInfo=[] Additional information can be passed inside the array or [] if none
+	 * @param array $addInfo Additional information can be passed inside the array or [] if none
 	 * @return string ProcessID
 	 */
 	public function start( ProcessManager $manager, $data = [], $pid = null, $addInfo = [] ) {

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -13,12 +13,14 @@ class ProcessManager {
 	private ILoadBalancer $loadBalancer;
 	/** @var int Number of minutes after which to delete processes */
 	private $garbageInterval = 600;
+	private $addInfo;
 
 	/**
 	 * @param ILoadBalancer $loadBalancer
 	 */
-	public function __construct( ILoadBalancer $loadBalancer ) {
+	public function __construct( ILoadBalancer $loadBalancer, array $addInfo ) {
 		$this->loadBalancer = $loadBalancer;
+		$this->addInfo = $addInfo;
 	}
 
 	/**
@@ -48,7 +50,7 @@ class ProcessManager {
 	 * @return string
 	 */
 	public function startProcess( ManagedProcess $process, $data = [] ): string {
-		return $process->start( $this, $data, null, $sync );
+		return $process->start( $this, $data, $addInfo = $this->addInfo );
 	}
 
 	/**

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -13,6 +13,7 @@ class ProcessManager {
 	private ILoadBalancer $loadBalancer;
 	/** @var int Number of minutes after which to delete processes */
 	private $garbageInterval = 600;
+	/** @var array Any additional information passed down from the calling instance */
 	private $addInfo;
 
 	/**
@@ -50,7 +51,7 @@ class ProcessManager {
 	 * @return string
 	 */
 	public function startProcess( ManagedProcess $process, $data = [] ): string {
-		return $process->start( $this, $data, $addInfo = $this->addInfo );
+		return $process->start( $this, $data, null, $this->addInfo );
 	}
 
 	/**

--- a/src/ProcessManager.php
+++ b/src/ProcessManager.php
@@ -18,6 +18,7 @@ class ProcessManager {
 
 	/**
 	 * @param ILoadBalancer $loadBalancer
+	 * @param array $addInfo
 	 */
 	public function __construct( ILoadBalancer $loadBalancer, array $addInfo ) {
 		$this->loadBalancer = $loadBalancer;


### PR DESCRIPTION
- The new instance name is passed to the globals and then into the process manager component
- This will only happen when the instance is non root
- Handled the catching this globals data (having instance name) into addInfo inside process manager and can be used there in future.
- However I didn't test the component in the farm setup for now.